### PR TITLE
Simplify addon submission process

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ As an Addon reviewer you will:
 - GitHub is where much of the NVDA development ecosystem is already based.
 - Handles all the of the CRUD ([create, read, update, delete](https://en.wikipedia.org/wiki/CRUD)) for users, authentication is handled, and we can determine how a user relates to an addon repository and what their permissions are for that repository. Are they actually an owner / maintainer?
 - GitHub has a review system that allows for proposing changes and discussing these changes. We can leverage this for a store submission and review process.
-- GitHub PR's provided a atomic view of a store submission.
+- GitHub PR's provided an atomic view of a store submission.
 - Interested parties can 'watch' PR's they care about without being subjected to the noise from PR's they don't care about.
 - The result (open / merged / closed) of the PR is clear.
 - GitHub allows us to manage permissions for accepting reviews more easily.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Inspiration has been taken from [Windows Package Manager Community repo](https:/
 A highly automated process would be ideal, and we can keep the ideas in mind to work in that direction.
 
 The main goal of this is to enable an "NVDA addon store" accessible from within NVDA itself.
-In this proposal the word "store" is used to refer to the system used to store metadata about addon releses and API's to access this data.
+In this proposal the word "store" is used to refer to the system used to store metadata about add-on releases and APIs to access this data.
 Aims:
 - Enable any necessary, API, process, or infrastructure to support users to browse, search, install and update Addons for NVDA.
 - A secure and robust provision of addon-metadata.
@@ -112,7 +112,7 @@ For a full description of the schema see:` _tools/addonVersion_schema.json`
 
 Process to add a new NVDA-addon version:
 1. Fork the `NVDA-Addon-submission` repository
-1. On a new branch, copy the `_template_addon_relese.json` file. 
+1. On a new branch, copy the `_template_addon_release.json` file. 
    - Rename / move the file to `<publisher>/<addonName>/<version>.json`
    - `<publisher>` is the name of the add-on developer, E.G. "nvaccess"
    - `<addonName>` is the name of the add-on, E.G. "nv-speech-player"

--- a/README.md
+++ b/README.md
@@ -166,8 +166,15 @@ Notes:
 - 'NVDA API Version' will be something like '2019.3', there will be one folder for each NVDA API Version.
 - The `pre-rel.json` and `release.json` contain the information necessary for a store entry.
 - The contents of `all.data` is all (pre-release and release) data for this NVDA API version together.
+- The contents for each addon will include all the technical details required for NVDA to download, verify file integrity, and install.
+- The file will include translations (if available) for the displayable metadata.
 
 The simplicity of this is that the NV Access server can just forward these files on directly when asked "what are the latest Addons for NVDA API Version X" or "What is the latest version of Addon-ID for NVDA API Version X". Using the NV Access server as the endpoint for this is important in case the implementation has to change or be migrated away from GitHub for some reason.
+
+### Questions
+- Should the `_ds` be stored in another repository?
+- Rather than another repository, `_ds` could be available only on a particular branch.
+- 
 
 ## Suffix
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Many of these can be automated.
 - The version number from the file name is valid and matches the version in the manifest.
 
 ### Concerns
-- With this ID scheme many add-ons will need to change their ID. Will require previously saved config to be moved to a new section?
+- With this ID scheme many add-ons will need to change their ID. Will this require previously saved user config to be moved to a new section of the config file?
 
 ### Other notes
 - By using a git repository and and PR process, `git blame` and `git log` can be used to get more context about addons listed in the store. For instance:
@@ -146,21 +146,25 @@ Many of these can be automated.
 
 ## API data generation details
 
-Github actions can be configured to run a commit modifies a certain path, E.G. `addons/`.
-This can regenerate the required views of the data, and commit it the `_ds` path.
-A second Github action can be configured to run when there is a commit to the `_ds` path, which will then trigger a Webhook to notify the API server of the changes.
+The NV Access server will be configured to respond to a Webhook to pull from this repository and run code to transform
+the data.
+This can regenerate the required views of the data for the exposed API's
 
 ### Overview
 
-For each version of NVDA, the meta-data of the most recent (the highest version number) of each Addon is automatically added, based on the data in 'NVDA-Addon-submission'.
+For each version of NVDA, the meta-data of the most recent (the highest version number) of each Addon is automatically
+added, based on the data in 'addon-store-submission'.
 
-### Layout
+Code for this will be stored in the `_tools` folder. This will enable interested parties to generate the same view of
+the data locally.
 
-Root directory of repository:
-- `/_ds/NVDA API Version/addon-1-ID/release.json`
-- `/_ds/NVDA API Version/addon-1-ID/pre-rel.json`
-- `/_ds/NVDA API Version/addon-2-ID/release.json`
-- `/_ds/NVDA API Version/all.json`
+### Data views
+
+Required transformations of the data:
+- `/NVDA API Version/addon-1-ID/release.json`
+- `/NVDA API Version/addon-1-ID/pre-rel.json`
+- `/NVDA API Version/addon-2-ID/release.json`
+- `/NVDA API Version/all.json`
 
 Notes:
 - 'NVDA API Version' will be something like '2019.3', there will be one folder for each NVDA API Version.
@@ -169,12 +173,10 @@ Notes:
 - The contents for each addon will include all the technical details required for NVDA to download, verify file integrity, and install.
 - The file will include translations (if available) for the displayable metadata.
 
-The simplicity of this is that the NV Access server can just forward these files on directly when asked "what are the latest Addons for NVDA API Version X" or "What is the latest version of Addon-ID for NVDA API Version X". Using the NV Access server as the endpoint for this is important in case the implementation has to change or be migrated away from GitHub for some reason.
-
-### Questions
-- Should the `_ds` be stored in another repository?
-- Rather than another repository, `_ds` could be available only on a particular branch.
-- 
+The simplicity of this is that the NV Access server can just forward these files on directly when asked
+"what are the latest Addons for NVDA API Version X" or "What is the latest version of Addon-ID for NVDA API Version X".
+Using the NV Access server as the endpoint for this is important in case the implementation has to change or be migrated
+away from GitHub for some reason.
 
 ## Suffix
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ As an Addon reviewer you will:
 
 ## Infrastructure
 
-- `NVDA-Addon-submission` GitHub Repository
+- `addon-store-submission` GitHub Repository
   - For Addon authors / reviewers.
   - Where new Addon versions are submitted
   - Where reviews of Addon submissions happen
@@ -82,7 +82,7 @@ As an Addon reviewer you will:
   - While this is technically not necessary, it provides a good separation from implementation.
     If we wished to change our storage mechanism, we would not be breaking old versions of NVDA.
 
-## `NVDA-Addon-submission` GitHub Repository
+## `addon-store-submission` GitHub Repository
 
 Essentially this repository holds metadata about all the accepted versions of Addons which are included in the store.
 Metadata about old versions of an addon remains until it is explicitly removed or becomes invalid, allowing delivery to older versions of NVDA, or as a fall back in case the newer version is revoked after a critical bug is found.
@@ -111,13 +111,13 @@ For a full description of the schema see:` _tools/addonVersion_schema.json`
 - Familiarity with Git, including working with branches.
 
 Process to add a new NVDA-addon version:
-1. Fork the `NVDA-Addon-submission` repository
+1. Fork the `addon-store-submission` repository
 1. On a new branch, copy the `_template_addon_release.json` file. 
    - Rename / move the file to `<publisher>/<addonName>/<version>.json`
    - `<publisher>` is the name of the add-on developer, E.G. "nvaccess"
    - `<addonName>` is the name of the add-on, E.G. "nv-speech-player"
    - `<version>` is the add-on version in the form: `Major.Minor.Patch` E.G. "2.4.1"
-1. Create a PR on `NVDA-Addon-submission` repository
+1. Create a PR on `addon-store-submission` repository
 1. Automated checks for common issues will complete.
 1. A review is performed (resulting in: request changes, approval)
    - Conducted by an NVDA add-on reviewer.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,44 @@
 # Add on Store Proposal
 
-The intention of this proposal is to improve the end to end process and supporting infrastructure for hosting Addons.
-This is the current plan from NV Access.
-However, before starting this work we would like feedback from the add-ons community, particularly addon authors and addon reviewers since this will affect them the most.
+The intention of this proposal is to improve the end-to-end process and supporting infrastructure for hosting Addons.
+This is the current plan from NV Access, it is a simplification of a [more complicated and highly automated plan](https://github.com/nvaccess/addon-store-submission/blob/c7d6f4fd9187fd0112de66b00caa62d774430d09/README.md). 
+Inspiration has been taken from [Windows Package Manager Community repo](https://github.com/microsoft/winget-pkgs)
+A highly automated process would be ideal, and we can keep the ideas in mind to work in that direction.
 
 The main goal of this is to enable an "NVDA addon store" accessible from within NVDA itself.
-In this proposal the word "store" is used to refer to the system allowing users to acquire addons, there is no intention of supporting paid addons.
-This "store" system includes any website, API, process, or infrastructure to support users to browse, search, install and update Addons for NVDA.
-
-Many considerations in this proposal have been given to creating a more secure and robust NVDA Addon store.
-While there is little that can be done to guarantee an addon is safe to run, we can ensure that all versions are viewed, and that users are running the addon they think they are.
-The process is intended to be as transparent as possible to make it simple (for developers) to understand the current state of the store or the state of a submission of a new / updated addon pending review.
+In this proposal the word "store" is used to refer to the system used to store metadata about addon releses and API's to access this data.
+Aims:
+- Enable any necessary, API, process, or infrastructure to support users to browse, search, install and update Addons for NVDA.
+- A secure and robust provision of addon-metadata.
+- There is no intention of supporting paid addons at this stage.
+- The process is intended to be as transparent as possible to make it simple (for developers) to understand the current state of the store or the state of a submission of a new / updated addon pending review.
 The process should enable authors and reviewers to learn about and improve the addon-review process.
 
-Much of the recent [conversation on the addons mailing list](https://nvda-addons.groups.io/g/nvda-addons/topic/69393202#10878) has been about reviewing Addons.
-While NV Access has some opinions on this, I think it will be more productive to first focus on the steps around this.
-For now, this step will just be referred to as 'review performed'.
-Later, I suggest a new thread to agree on a "addon review check list".
-With the right infrastructure, we can automate many checks and reduce the burden on reviewers.
+### About security 
+Ensure that an add-on itself is safe to run, is a challenge that won't be addressed by this proposal.
+Instead, this system can ensure that all updates to the metadata for add-on versions are reviewed, and allows clients of the system (website, NVDA) to verify that the addon package still matches what was reviewed.
 
+### Past discussions
+- About review process [conversation on the addons mailing list](https://nvda-addons.groups.io/g/nvda-addons/topic/69393202#10878) has been about reviewing Addons.
+- While NV Access has some opinions on the review process, this proposal will first concern itself with the mechanics of the system rather than the considerations for a reviewer when looking at an addon.
+For now, this step will just be referred to as 'review of addon performed'.
+Later a "addon review check list" will be created.
+
+### Non-exclusivity
 This proposal does not intend to restrict Addon authors from developing, publishing, and distributing Addons outside of this store.
 NVDA will still allow local installation from a `*.nvda-addon` file.
 
 ## Too Long; Didn't Read for Addon authors
 With this proposal if an addon author wishes to submit their addon to be visible in this addon store they will need to:
-- Store their addon on Github in an open (not private) repository.
-- Create an issue on the `addon-store-submission` repository for each addon version they want to make available.
-- Paste into the issue description a link to the commit or github release.
-- Wait for it to be reviewed and accepted or participate in review actions and resubmit the new version.
+- Add a file to this repo (via a pull request) containing metadata about published addons, including a download URL and hash of the addon package.
+- To facilitate reviews, store their addon in an open (not private) repository.
+- Get an "add-on reviewer" to review your addon and metadata submission, when this is approved it will be merged making it available.
 
 ## Too Long; Didn't Read for Addon reviewers
 As an Addon reviewer you will:
 - Look at pending PR's on the `addon-store-submission` repository.
-- These will include a link to the addon version being reviewed.
-- Follow the review process (yet to be documented here).
-- Either 'approve' the PR, or 'request changes' while providing feedback and close the PR.
-- When approving the PR, press the merge button to finalise the submision.
+- Follow the review process (yet to be documented).
+- Either 'approve' the PR, or 'request changes' while providing feedback.
 
 ## Considerations
 
@@ -52,9 +55,10 @@ As an Addon reviewer you will:
 
 ## Overview
 
-Use GitHub reviews for store submissions.
-Use GitHub for storage of meta-data for addons available from the store.
-Use GitHub actions (or other integrations) to automate construction of the data store, and as many of the review checks as possible. This will all be open source and extensible by the community.
+- Use GitHub reviews for store submissions.
+- Use GitHub for storage of meta-data for addons available from the store.
+- Use GitHub actions (or other integrations) to automate construction of the data store, and as many of the review checks as possible.
+  This will all be open source and extensible by the community.
 
 ### Why GitHub reviews?
 - GitHub is where much of the NVDA development ecosystem is already based.
@@ -71,7 +75,6 @@ Use GitHub actions (or other integrations) to automate construction of the data 
   - For Addon authors / reviewers.
   - Where new Addon versions are submitted
   - Where reviews of Addon submissions happen
-- `NVDA-Addon-store-data` GitHub Repository
   - For storage of meta-data about addons "in the store"
   - This repository acts as a back-end database, but is more transparent.
   - Since our needs are simple, preconfigured "views" of the data will suffice.
@@ -81,80 +84,58 @@ Use GitHub actions (or other integrations) to automate construction of the data 
 
 ## `NVDA-Addon-submission` GitHub Repository
 
-Essentially this repository holds references to all the accepted versions of Addons which are included in the store. A reference to an old version of an addon remains until it is explicitly removed or becomes invalid, allowing delivery to older versions of NVDA, or as a fall back in case the newer version is revoked after a critical bug is found.
-Addons versions are submitted by submitting a pull request, adding the commit for that version to a file that describes the GitHub repository for the addon.
+Essentially this repository holds metadata about all the accepted versions of Addons which are included in the store.
+Metadata about old versions of an addon remains until it is explicitly removed or becomes invalid, allowing delivery to older versions of NVDA, or as a fall back in case the newer version is revoked after a critical bug is found.
+Addons versions are submitted by submitting a pull request, adding a file for that version of the addon.
 
 ### Layout
 
 Root directory of repository:
  - `readme.md` - A guide for submission
- - `addons/owner1/repo1.commits`
- - `addons/owner1/repo2.commits`
- - `addons/owner2/repo3.commits`
+ - `addons/publisher1/addon1/majorVersion.minorVersion.patch.json`
+ - `addons/publisher1/addon2/majorVersion.minorVersion.patch.json`
+ - `addons/publisher2/addon3/majorVersion.minorVersion.patch.json`
 
-Example for the NV Access addon, 'NVDA - OCR': `addons/nvaccess/nvda-ocr.commits`
+Note: `publisher.addonName` will become the addon ID, and must be unique and match the addon ID from the addon manifest.
 
-Contents of a `*.commits` file, is a (newline separated) list of git SHAs, one for each commit which could be available in the store.
-This is intentionally a very simple format to maximise the ease of editing, and minimise the risk of format corruption.
-Commits are used rather than tags because tags can be changed after creation, a SHA collision should be quite difficult to achieve.
-This is important to stop the possibility of a malicious author changing an addon post review, bypassing the review process.
+Example for the NV Access addon, 'NVDA - OCR': `addons/nvaccess/nvda-ocr/1.6.0.json`
+
+### Metadata format
+For a full description of the schema see:` _tools/addonVersion_schema.json`
+- This includes an example of the file contents.
 
 ### Submitting an Addon version
 
-Pre-requisites:
-- An addon must be stored on GitHub in a public repository
-- The commit which will be submitted must be a valid NVDA `*.nvda-addon` file if zipped and renamed.
+#### Pre-requisites:
+- Familiarity with GitHub
+- Familiarity with Git, including working with branches.
 
-Process:
-1. A PR is created on the `NVDA-Addon-submission` repository
-   - It adds/removes the SHA of the commit (for the submitted version) to the appropriate `addons/owner/repo.commits` file.
-   - Refer to 'Creating the submission PR' below
-1. A bot adds a comment in the PR with links to the addon versions that are added or removed
-   - NOTE: the URL for this link can be is built from 'owner', 'repo', 'commit' of the lines added / removed. 
-   - This allows the reviewer to browse the source online or download the addon with, see (in suffix) heading "Example of bot message for `NVDA-Addon-submission` PR" for an example message.
-1. A review is performed (resulting in: request changes, merge, close)
-   - A bot may perform some automated checks or provide helpful information, refer to 'automated review ideas' below
+Process to add a new NVDA-addon version:
+1. Fork the `NVDA-Addon-submission` repository
+1. On a new branch, copy the `_template_addon_relese.json` file. 
+   - Rename / move the file to `<publisher>/<addonName>/<version>.json`
+   - `<publisher>` is the name of the add-on developer, E.G. "nvaccess"
+   - `<addonName>` is the name of the add-on, E.G. "nv-speech-player"
+   - `<version>` is the add-on version in the form: `Major.Minor.Patch` E.G. "2.4.1"
+1. Create a PR on `NVDA-Addon-submission` repository
+1. Automated checks for common issues will complete.
+1. A review is performed (resulting in: request changes, approval)
+   - Conducted by an NVDA add-on reviewer.
    - Manual review is done according to some published review check list (so that everyone knows what to expect)
-   - Automated and human process can be decided later, we can address these details as they come up and improve upon the process
-1. When the PR is merged, the Addon becomes available in the store.
+1. The PR is merged, the add-on becomes available in the store.
 
-### Creating the submission PR
-To simplify the initial implementation of this process the PR will need to be created manually, later we can streamline this, and automate only requiring the addon author to paste a link in a new issue.
 
-A new Pull Request (PR) is created on the `NVDA-Addon-submission` repository.
-   1. Find or create a file: `addons/owner/repo.commits`
-      - Example: `addons/nvaccess/nvda-ocr.commits`
-      - Where 'owner' is the username or organisation that owns the addon GitHub repository. E.G. for `nvda-ocr` it is `nvaccess`
-      - Where 'repo' is the name of the repository. E.G. `nvda-ocr`
-      - NOTE: creating the file means this is an entirely new submission
-   1. To submit a new version, add the SHA of the commit to the file
-   1. For no longer supported addon versions, remove the SHA of the commit.
-This could be done with the web editor, though screen reader users may be more comfortable making the changes locally with their chosen editor.
-
-Because this requires addon authors to fork the `NVDA-Addon-submission` repository, this is a little cumbersome.
-To streamline this process, we could use GitHub issues.
-- The addon author would pick from two issue templates:
-  - "Add addon version"
-  - "Remove addon version"
-- In the template they would paste a link to the commit or tag that should be added or removed.
-- Automation creates the PR automatically from this and closes the issue.
-- NOTE: In this approach it is safe to use a git tag, because the commit ID can be determined from the tag. The commit is then used in the PR and the rest of the process is the same.
-
-### Automated review ideas
-Several suggestions for automated review ideas to streamline the process.
-- Check manifest validity
-- Provide links to relevant diffs
-- Check to see if the GitHub user submitting the PR is a maintainer of the Addon version being submitted.
-- Consider using CI (Appveyor) to check the addon installs cleanly:
-  - Install NVDA (the most recent version supported by the addon)
-  - Install the addon
-  - Restart NVDA and check for errors
+### Checked during review
+Many of these can be automated.
+- Each modified file conforms to the schema
+- Download URL is valid
+- File from URL matches Sha256
+- Version number matches add-on manifest.
+- The file ID (`<publisher>.<addonName>`) matches the manifest 'name' field
+- The version number from the file name is valid and matches the version in the manifest.
 
 ### Concerns
-This approach requires that an addon repository is already a valid (and installable) addon once it is zipped. Most addons require build steps.
- - Can github actions be used to run these steps and produce a certifiable build artifact?
-   - If we can certify the source for a commit, and the source for the github actions that produces the artifact, then the artifact itself is certified?
-   - If this is true we can provide this action along with the addon-template.
+- With this ID scheme many add-ons will need to change their ID. Will require previously saved config to be moved to a new section?
 
 ### Other notes
 - By using a git repository and and PR process, `git blame` and `git log` can be used to get more context about addons listed in the store. For instance:
@@ -163,63 +144,32 @@ This approach requires that an addon repository is already a valid (and installa
   - How often does this addon have updates accepted
 - GitHub allows assigning reviews to reviewers
 
-## `NVDA-Addon-store-data` GitHub Repository
+## API data generation details
 
-Holds meta-data about addons accepted to the store.
-
-Using a separate repository for this data store separates concerns, gives greater flexibility for managing permissions, makes it easier to verify changes (eg in a PR, or via automation), and simplifies the commit history (no automation commits "updating data store")
-
-The exact implementation details for this repository are not exposed to users, because on one side the `NVDA-Addon-submission` repository feeds data in and the NV Access server is on the other side fetching and providing data to NVDA or a web based store.
-This means that changing the layout or implementation of this repository does not cause wide breaking changes to the process and it can be updated independently.
-Since the details of this repository don't really matter too much they don't need to be concrete at this point, however I'll give a brief overview of the current plan.
+Github actions can be configured to run a commit modifies a certain path, E.G. `addons/`.
+This can regenerate the required views of the data, and commit it the `_ds` path.
+A second Github action can be configured to run when there is a commit to the `_ds` path, which will then trigger a Webhook to notify the API server of the changes.
 
 ### Overview
 
-For each version of NVDA, the meta-data of the most recent (highest version number) of each Addon is automatically added, based on the data in 'NVDA-Addon-submission'.
+For each version of NVDA, the meta-data of the most recent (the highest version number) of each Addon is automatically added, based on the data in 'NVDA-Addon-submission'.
 
 ### Layout
 
 Root directory of repository:
-- `/NVDA API Version/addon-1-ID/release.json`
-- `/NVDA API Version/addon-1-ID/pre-rel.json`
-- `/NVDA API Version/addon-2-ID/release.json`
-- `/NVDA API Version/all.json`
+- `/_ds/NVDA API Version/addon-1-ID/release.json`
+- `/_ds/NVDA API Version/addon-1-ID/pre-rel.json`
+- `/_ds/NVDA API Version/addon-2-ID/release.json`
+- `/_ds/NVDA API Version/all.json`
 
 Notes:
 - 'NVDA API Version' will be something like '2019.3', there will be one folder for each NVDA API Version.
 - The `pre-rel.json` and `release.json` contain the information necessary for a store entry.
-  This is essentially the URL to download the addon (a zip of the commit), and the rest of the contents of the addon manifest. Of course, by including translated descriptions in the manifest a multilingual addon store can be created, though possible not the core goal of this proposal.
 - The contents of `all.data` is all (pre-release and release) data for this NVDA API version together.
 
 The simplicity of this is that the NV Access server can just forward these files on directly when asked "what are the latest Addons for NVDA API Version X" or "What is the latest version of Addon-ID for NVDA API Version X". Using the NV Access server as the endpoint for this is important in case the implementation has to change or be migrated away from GitHub for some reason.
 
-### How does data arrive
-For the sake of a simple explanation, optimisations and minor details will be omitted from this description.
-
-A GitHub Action is created to respond to a new commit on the `NVDA-Addon-submission` repository. For each commit in each `*.commits` file in the `NVDA-Addon-submission` repository, the manifest for the addon is fetched.
-
-Addons manifests that support each NVDA API version are found.
-For each NVDA API version the most recent (based on version number) release and pre-release addon manifest is kept.
-
-These remaining manifest files are used to reconstruct the data in the repository and commit it.
-
 ## Suffix
-
-### Example of bot message for `NVDA-Addon-submission` PR.
-
-```
-Added Version.
-- [Browse source](https://github.com/nvaccess/nvda-ocr/tree/632d037dae906cd582ff4995628aa3fbaacd84e9)
-- [Download zip](https://github.com/nvaccess/nvda-ocr/archive/632d037dae906cd582ff4995628aa3fbaacd84e9.zip)
-```
-
-### Pre-release addon version support
-
-This will require an update to the addon-manifest. While this proposal plans for it, it will not be in the initial scope of work.
-
-### Invalid Addon references
-
-When building the data-store, any references to commits that no longer exist (repo deleted, history rewritten etc) will obviously be excluded since the manifest can not be fetched. Although not high priority, a mechanism may need to be developed to update the 'NVDA-Addon-submission' repository so that these invalid references can be removed.
 
 ### Terminology: Addon version vs Addon release
 

--- a/_tools/addonVersion_schema.json
+++ b/_tools/addonVersion_schema.json
@@ -1,0 +1,236 @@
+{
+    "examples": [
+        {
+            "name": "My addon",
+            "description": "Makes doing XYZ easier",
+            "homepage": "https://github.com/nvaccess/addon-store-submission",
+            "minNVDAVersion": {
+                "major": 2019,
+                "minor": 3,
+                "patch": 0
+            },
+            "lastTestedVersion": {
+                "major": 2020,
+                "minor": 4,
+                "patch": 0
+            },
+            "channel": "beta",
+            "URL": "https://github.com/nvaccess/addon-store-submission/releases/download/v0.1.0/myAddon.nvda-addon",
+            "sha256": "69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82",
+            "sourceURL": "https://github.com/nvaccess/addon-store-submission/",
+            "license": "GPL v2",
+            "licenseURL": "https://github.com/nvaccess/addon-store-submission/license.MD"
+        }
+    ],
+    "required": [
+        "name",
+        "description",
+        "minNVDAVersion",
+        "lastTestedVersion",
+        "channel",
+        "URL",
+        "sha256",
+        "sourceURL",
+        "license",
+        "licenseURL"
+    ],
+    "type": "object",
+    "properties": {
+        "name": {
+            "$id": "#/properties/name",
+            "default": "",
+            "description": "The name that will be displayed in English for the addon.",
+            "examples": [
+                "My addon"
+            ],
+            "title": "The display name (en) of the addon",
+            "type": "string"
+        },
+        "description": {
+            "$id": "#/properties/description",
+            "default": "",
+            "description": "The English description of the addon that will be displayed for the addon.",
+            "examples": [
+                "Makes doing XYZ easier"
+            ],
+            "title": "The description (en) of the addon",
+            "type": "string"
+        },
+        "homepage": {
+            "$id": "#/properties/homepage",
+            "default": "",
+            "description": "If the addon has a homepage where users can get more information about the addon, you can specify it here.",
+            "examples": [
+                "https://github.com/nvaccess/addon-store-submission"
+            ],
+            "title": "The homepage URL for the addon.",
+            "type": "string"
+        },
+        "minNVDAVersion": {
+            "$id": "#/properties/minNVDAVersion",
+            "default": {},
+            "description": "The addon will not work with versions of NVDA prior to this version.",
+            "examples": [
+                {
+                    "major": 2019,
+                    "minor": 3,
+                    "patch": 0
+                }
+            ],
+            "required": [
+                "major",
+                "minor",
+                "patch"
+            ],
+            "title": "The minNVDAVersion required for the addon",
+            "type": "object",
+            "properties": {
+                "major": {
+                    "$id": "#/properties/minNVDAVersion/properties/major",
+                    "default": 0,
+                    "description": "'major' in major.minor.patch",
+                    "examples": [
+                        2019
+                    ],
+                    "title": "The 'major' part of the version number.",
+                    "type": "integer"
+                },
+                "minor": {
+                    "$id": "#/properties/minNVDAVersion/properties/minor",
+                    "default": 0,
+                    "description": "The 'minor' part in major.minor.patch",
+                    "examples": [
+                        3
+                    ],
+                    "title": "The 'minor' part of the version number.",
+                    "type": "integer"
+                },
+                "patch": {
+                    "$id": "#/properties/minNVDAVersion/properties/patch",
+                    "default": 0,
+                    "description": "The 'patch' part in major.minor.patch",
+                    "examples": [
+                        0
+                    ],
+                    "title": "The 'patch' part of the version number.",
+                    "type": "integer"
+                }
+            }
+        },
+        "lastTestedVersion": {
+            "$id": "#/properties/lastTestedVersion",
+            "type": "object",
+            "title": "The lastTestedVersion schema",
+            "description": "An explanation about the purpose of this instance.",
+            "default": {},
+            "examples": [
+                {
+                    "major": 2020,
+                    "minor": 4,
+                    "patch": 0
+                }
+            ],
+            "required": [
+                "major",
+                "minor",
+                "patch"
+            ],
+            "properties": {
+                "major": {
+                    "$id": "#/properties/lastTestedVersion/properties/major",
+                    "default": 0,
+                    "description": "'major' in major.minor.patch",
+                    "examples": [
+                        2020
+                    ],
+                    "title": "The 'major' part of the version number.",
+                    "type": "integer"
+                },
+                "minor": {
+                    "$id": "#/properties/lastTestedVersion/properties/minor",
+                    "default": 0,
+                    "description": "The 'minor' part in major.minor.patch",
+                    "examples": [
+                        4
+                    ],
+                    "title": "The 'minor' part of the version number.",
+                    "type": "integer"
+                },
+                "patch": {
+                    "$id": "#/properties/lastTestedVersion/properties/patch",
+                    "default": 0,
+                    "description": "The 'patch' part in major.minor.patch",
+                    "examples": [
+                        0
+                    ],
+                    "title": "The 'patch' part of the version number.",
+                    "type": "integer"
+                }
+            }
+        },
+        "channel": {
+            "$id": "#/properties/channel",
+            "default": "",
+            "description": "Used to define pre-release (beta) add-ons. Should be either 'stable' or 'beta'",
+            "examples": [
+                "beta"
+            ],
+            "title": "The channel for the addon",
+            "enum": [
+                "stable",
+                "beta"
+            ],
+            "type": "string"
+        },
+        "URL": {
+            "$id": "#/properties/URL",
+            "default": "",
+            "description": "To allow directly downloading the *.nvda-addon file. The URL should remain valid indefinetly. GitHub release URL's are recommended.",
+            "examples": [
+                "https://github.com/nvaccess/addon-store-submission/releases/download/v0.1.0/myAddon.nvda-addon"
+            ],
+            "title": "The URL to download the add-on.",
+            "type": "string"
+        },
+        "sha256": {
+            "$id": "#/properties/sha256",
+            "default": "",
+            "description": "Use the python script '_tools/genSha256.py' to generate this value.",
+            "examples": [
+                "69D84CA8899800A5575CE31798293CD4FEBAB1D734A07C2E51E56A28E0DF8C82"
+            ],
+            "title": "The sha256 for the *.nvda-addon file.",
+            "type": "string"
+        },
+        "sourceURL": {
+            "$id": "#/properties/sourceURL",
+            "default": "",
+            "description": "Allows reviewers to inspect the source code for common issues.",
+            "examples": [
+                "https://github.com/nvaccess/addon-store-submission/"
+            ],
+            "title": "The URL for the add-on source",
+            "type": "string"
+        },
+        "license": {
+            "$id": "#/properties/license",
+            "default": "",
+            "description": "The short name of the license.",
+            "examples": [
+                "GPL v2"
+            ],
+            "title": "The short name of the license for the addon",
+            "type": "string"
+        },
+        "licenseURL": {
+            "$id": "#/properties/licenseURL",
+            "default": "",
+            "description": "A URL to the full license for the addon.",
+            "examples": [
+                "https://github.com/nvaccess/addon-store-submission/license.MD"
+            ],
+            "title": "The licenseURL schema",
+            "type": "string"
+        }
+    }
+}

--- a/_tools/addonVersion_schema.json
+++ b/_tools/addonVersion_schema.json
@@ -121,7 +121,7 @@
             "$id": "#/properties/lastTestedVersion",
             "type": "object",
             "title": "The lastTestedVersion schema",
-            "description": "An explanation about the purpose of this instance.",
+            "description": "The add-on has been tested up to and including this version of NVDA",
             "default": {},
             "examples": [
                 {

--- a/_tools/sha256.py
+++ b/_tools/sha256.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+# Copyright (C) 2020 NV Access Limited
+# This file may be used under the terms of the GNU General Public License, version 2 or later.
+# For more details see: https://www.gnu.org/licenses/gpl-2.0.html
+
+import hashlib
+import argparse
+import typing
+
+#: The read size for each chunk read from the file, prevents memory overuse with large files.
+BLOCK_SIZE = 65536
+
+def sha256_checksum(binaryReadModeFile: typing.BinaryIO, blockSize: int = BLOCK_SIZE):
+	"""
+	:param binaryReadModeFile: An open file (mode=='rb'). Calculate its sha256 hash.
+	:param blockSize: The size of each read.
+	:return: The Sha256 hex digest.
+	"""
+	sha256 = hashlib.sha256()
+	assert binaryReadModeFile.readable() and binaryReadModeFile.mode == 'rb'
+	f = binaryReadModeFile
+	for block in iter(lambda: f.read(blockSize), b''):
+		sha256.update(block)
+	return sha256.hexdigest()
+
+def main():
+	parser = argparse.ArgumentParser()
+	parser.add_argument(
+		type=argparse.FileType('rb'),
+		dest="file",
+		help="The NVDA addon (*.nvda-addon) to use when computing the sha256."
+	)
+	args = parser.parse_args()
+	checksum = sha256_checksum(args.file)
+	print("Sha256:"+ '\t' + checksum)
+
+if __name__ == '__main__':
+	main()

--- a/_tools/sha256.py
+++ b/_tools/sha256.py
@@ -33,7 +33,7 @@ def main():
 	)
 	args = parser.parse_args()
 	checksum = sha256_checksum(args.file)
-	print("Sha256:"+ '\t' + checksum)
+	print(f"Sha256:\t{checksum}")
 
 if __name__ == '__main__':
 	main()


### PR DESCRIPTION
This is a counter-proposal, simplifying the previously proposed process. This process could be adopted almost immediately. The result of this would be that this process becomes the only interface that add-on authors and reviewers need to interact with. NV Access (perhaps supported by addon authors initially) can fulfill the requirements for interacting with other repositories and over time automate those aspects.

The remaining steps that will need to be completed manually:
- Update the [get.php file](https://github.com/nvaccess/addonFiles/blob/master/get.php)
- If necessary update the 'addonFiles' repo:
   -  Push your changes to your fork of add-on files repository and a branch name of the form ‘addonName-version”
      - e.g. winTenApps-20.12 for Windows 10 App Essentials 20.12 release info branch.
  - Create a pull request against the [NV Access add-on files repo.](https://github.com/nvaccess/addonFiles)
  - Wait for NV Access to approve it, NV Access will give preference to PR's that have been approved by prominent Add-on reviewers.
- If necessary add an entry in community add-ons website.