### PR TITLE
change readme to match transformAddonDataToViews

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ This code will have automated tests.
 ### Data views
 The following views will only be available on a `views` branch, and located in a `views` folder.
 Required transformations of the data:
-- `/NVDA API Version/addon-1-ID/release.json`
+- `/NVDA API Version/addon-1-ID/stable.json`
 - `/NVDA API Version/addon-1-ID/beta.json`
-- `/NVDA API Version/addon-2-ID/release.json`
+- `/NVDA API Version/addon-2-ID/stable.json`
 
 Notes:
 - 'NVDA API Version' will be something like '2019.3', there will be one folder for each NVDA API Version.
-- The `beta.json` and `release.json` contain the information necessary for a store entry.
+- The `beta.json` and `stable.json` contain the information necessary for a store entry.
 - The contents for each addon will include all the technical details required for NVDA to download, verify file integrity, and install.
 - The file will include translations (if available) for the displayable metadata.
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You are welcome to review code / UX of addons and provide that feedback directly
   submission made to the Add-on Store.
 - Allow addon authors to easily revoke a version if it is buggy / no longer supported.
   Removed releases are no longer presented in the store, halting new installations.
-- Enable support in the store for multiple versions of an Addon, based on NVDA version.
+- Enable support in the store for multiple versions of an Addon, based on NVDA API version.
   - EG addon version 1.2.5 for NVDA 2019.3 and addon version 1.3.2 for NVDA 2020.1
 - Enable support in the store for 'beta' Addons, for instance:
   - Addons being developed against alpha / beta NVDA.
@@ -167,18 +167,18 @@ This code will have automated tests.
 ### Data views
 The following views will only be available on a `views` branch, and located in a `views` folder.
 Required transformations of the data:
-- `/NVDA Version/addon-1-ID/release.json`
-- `/NVDA Version/addon-1-ID/beta.json`
-- `/NVDA Version/addon-2-ID/release.json`
+- `/NVDA API Version/addon-1-ID/release.json`
+- `/NVDA API Version/addon-1-ID/beta.json`
+- `/NVDA API Version/addon-2-ID/release.json`
 
 Notes:
-- 'NVDA Version' will be something like '2019.3', there will be one folder for each NVDA Version.
+- 'NVDA API Version' will be something like '2019.3', there will be one folder for each NVDA API Version.
 - The `beta.json` and `release.json` contain the information necessary for a store entry.
 - The contents for each addon will include all the technical details required for NVDA to download, verify file integrity, and install.
 - The file will include translations (if available) for the displayable metadata.
 
 The simplicity of this is that the NV Access server can just forward these files on directly when asked
-"what are the latest Addons for NVDA Version X" or "What is the latest version of Addon-ID for NVDA Version X".
+"what are the latest Addons for NVDA API Version X" or "What is the latest version of Addon-ID for NVDA API Version X".
 Using the NV Access server as the endpoint for this is important in case the implementation has to change or be migrated
 away from GitHub for some reason.
 

--- a/README.md
+++ b/README.md
@@ -56,10 +56,10 @@ You are welcome to review code / UX of addons and provide that feedback directly
   Removed releases are no longer presented in the store, halting new installations.
 - Enable support in the store for multiple versions of an Addon, based on NVDA version.
   - EG addon version 1.2.5 for NVDA 2019.3 and addon version 1.3.2 for NVDA 2020.1
-- Enable support in the store for 'pre-release' Addons, for instance:
+- Enable support in the store for 'beta' Addons, for instance:
   - Addons being developed against alpha / beta NVDA.
   - Addons that want early feedback from end users.
-  - End users can choose "show me pre-release addons"
+  - End users can choose "show me beta addons"
 
 ## Overview
 
@@ -167,20 +167,18 @@ This code will have automated tests.
 ### Data views
 The following views will only be available on a `views` branch, and located in a `views` folder.
 Required transformations of the data:
-- `/NVDA API Version/addon-1-ID/release.json`
-- `/NVDA API Version/addon-1-ID/pre-rel.json`
-- `/NVDA API Version/addon-2-ID/release.json`
-- `/NVDA API Version/all.json`
+- `/NVDA Version/addon-1-ID/release.json`
+- `/NVDA Version/addon-1-ID/beta.json`
+- `/NVDA Version/addon-2-ID/release.json`
 
 Notes:
-- 'NVDA API Version' will be something like '2019.3', there will be one folder for each NVDA API Version.
-- The `pre-rel.json` and `release.json` contain the information necessary for a store entry.
-- The contents of `all.data` is all (pre-release and release) data for this NVDA API version together.
+- 'NVDA Version' will be something like '2019.3', there will be one folder for each NVDA Version.
+- The `beta.json` and `release.json` contain the information necessary for a store entry.
 - The contents for each addon will include all the technical details required for NVDA to download, verify file integrity, and install.
 - The file will include translations (if available) for the displayable metadata.
 
 The simplicity of this is that the NV Access server can just forward these files on directly when asked
-"what are the latest Addons for NVDA API Version X" or "What is the latest version of Addon-ID for NVDA API Version X".
+"what are the latest Addons for NVDA Version X" or "What is the latest version of Addon-ID for NVDA Version X".
 Using the NV Access server as the endpoint for this is important in case the implementation has to change or be migrated
 away from GitHub for some reason.
 
@@ -188,4 +186,4 @@ away from GitHub for some reason.
 
 ### Terminology: Addon version vs Addon release
 
-Since this proposal supports pre-release addons, I have tried to avoid using the term "addon release", instead favouring "addon version".
+Since this proposal supports beta addons, I have tried to avoid using the term "addon release", instead favouring "addon version".


### PR DESCRIPTION
Reasons for changes:

* The channel "beta" and "stable" is used in the [validateNvdaAddonMetadata](https://github.com/nvaccess/validateNvdaAddonMetadata/blob/main/_validate/addonVersion_schema.json) repo. 
* `all.json` was deemed unnecessary