### PR TITLE
update current data to match new schema

### DIFF
--- a/addons/wintenApps/21.02.json
+++ b/addons/wintenApps/21.02.json
@@ -3,6 +3,12 @@
 	"publisher": "josephsl",
 	"description": "A collection of app modules for various Windows 10 apps",
 	"homepage": "https://addons.nvda-project.org/",
+	"addonId": "wintenApps",
+	"addonVersion": {
+		"major": 21,
+		"minor": 2,
+		"patch": 0
+	},
 	"minNVDAVersion": {
 		"major": 2020,
 		"minor": 3,

--- a/addons/wintenApps/21.2.0.json
+++ b/addons/wintenApps/21.2.0.json
@@ -4,7 +4,8 @@
 	"description": "A collection of app modules for various Windows 10 apps",
 	"homepage": "https://addons.nvda-project.org/",
 	"addonId": "wintenApps",
-	"addonVersion": {
+	"addonVersionName": "21.02",
+	"addonVersionNumber": {
 		"major": 21,
 		"minor": 2,
 		"patch": 0


### PR DESCRIPTION
Update submissions to match new schema: https://github.com/nvaccess/validateNvdaAddonMetadata/pull/5

This PR however demonstrates an issue with the version strings used by addons.
This addon treats the version like a "version name" rather than a "version number".
Note the addonFile is named: `21.02.json` rather than `21.2.json`.

Perhaps we can just rename the file?